### PR TITLE
Install yt from source

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -21,4 +21,11 @@ dependencies:
   - wheel
   # additional packages for demos
   - ipywidgets
-  - yt
+  - cython
+  - git
+  - sympy
+  - ipython
+  - matplotlib
+  - netCDF4
+  - pip:
+    - git+https://github.com/yt-project/yt\#egg=main

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -28,4 +28,4 @@ dependencies:
   - matplotlib
   - netCDF4
   - pip:
-    - git+https://github.com/yt-project/yt\#egg=main
+    - git+https://github.com/yt-project/yt.git@main#egg=yt

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -27,5 +27,6 @@ dependencies:
   - ipython
   - matplotlib
   - netCDF4
+  - pooch  # to load datasets from the yt repository
   - pip:
     - git+https://github.com/yt-project/yt.git@main#egg=yt

--- a/example/demo.ipyg
+++ b/example/demo.ipyg
@@ -11,9 +11,9 @@ from node_editor.graph import register_node, registry
 # % IPYS: Nodes
 @register_node
 def load_dataset(
-    path: str = "/home/ccc/Documents/prog/yt-data/output_00080/info_00080.txt",
+    path: str = "output_00080",
 ) -> Dataset:
-    ds = yt.load(path)
+    ds = yt.load_sample(path)
     ds.index
     return ds
 


### PR DESCRIPTION
Installs yt from source on binder rather than using yt-3. Should be changed once yt-4 is available from conda.