### PR TITLE
Uninstall jupyter-offlinenotebook, update binder link to point at demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # IpySpaghetti — WORK IN PROGRESS
 
-![Github Actions Status](https://github.com/cphyc/node_editor/workflows/Build/badge.svg)[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/cphyc/node_editor/main?urlpath=lab)
+![Github Actions Status](https://github.com/cphyc/node_editor/workflows/Build/badge.svg)[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/cphyc/node_editor/main?urlpath=lab/tree/example/demo.ipyg)
 
 A JupyterLab extension.
 

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -38,7 +38,7 @@ _(sys.executable, "-m", "pip", "check")
 # list the extensions
 _("jupyter", "server", "extension", "list")
 
-# remove Lab-3 incomptible extension
+# remove Lab-3 incompatible extension
 subprocess.call(["jupyter", "labextension", "uninstall", "--no-build", "jupyter-offlinenotebook"])
 
 # initially list installed extensions to determine if there are any surprises

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -38,6 +38,9 @@ _(sys.executable, "-m", "pip", "check")
 # list the extensions
 _("jupyter", "server", "extension", "list")
 
+# remove Lab-3 incomptible extension
+subprocess.call(["jupyter", "labextension", "uninstall", "--no-build", "jupyter-offlinenotebook"])
+
 # initially list installed extensions to determine if there are any surprises
 _("jupyter", "labextension", "list")
 


### PR DESCRIPTION
Success: got to it actually working in binder :tada:

![Screenshot from 2021-01-25 11-06-07](https://user-images.githubusercontent.com/45380/105731374-57efc400-5efd-11eb-9ed2-582a11550121.png)

This PR just:
- removes `jupyter-offlinenotebook` because the pop-up is gross
- points the binder link at the demo

If you hadn't considered it, this would be a great thing for folks to see at tomorrow's [Jupyter Community Call](https://discourse.jupyter.org/t/jupyter-community-calls/668/46)!